### PR TITLE
Use correct signer for context

### DIFF
--- a/Sources/Reset/Command/GeneratePasswordResetTokenCommand.swift
+++ b/Sources/Reset/Command/GeneratePasswordResetTokenCommand.swift
@@ -45,6 +45,12 @@ public struct GeneratePasswordResetTokenCommand<U: PasswordResettable>: Command 
     public func run(using context: CommandContext) throws -> Future<Void> {
         let container = context.container
         let query = try context.argument(Keys.query)
+        let config: ResetConfig<U> = try container.make()
+        let expirationPeriod = U.expirationPeriod(for: self.context)
+        let expirableSigner = ExpireableJWTSigner(
+            expirationPeriod: expirationPeriod,
+            signer: config.signer
+        )
 
         return container.withPooledConnection(to: databaseIdentifier) { connection in
             U
@@ -53,8 +59,7 @@ public struct GeneratePasswordResetTokenCommand<U: PasswordResettable>: Command 
                 .first()
                 .unwrap(or: ResetError.userNotFound)
                 .flatMap(to: String.self) { user in
-                    let signer = try U.signer(for: self.context, on: container)
-                    return try user.signToken(using: signer, on: container)
+                    return try user.signToken(using: expirableSigner, on: container)
                 }
                 .map {
                     context.console.print("Password Reset Token: \($0)")

--- a/Sources/Reset/Command/GeneratePasswordResetTokenCommand.swift
+++ b/Sources/Reset/Command/GeneratePasswordResetTokenCommand.swift
@@ -53,7 +53,7 @@ public struct GeneratePasswordResetTokenCommand<U: PasswordResettable>: Command 
                 .first()
                 .unwrap(or: ResetError.userNotFound)
                 .flatMap(to: String.self) { user in
-                    let signer = try user.signer(for: self.context, on: container)
+                    let signer = try U.signer(for: self.context, on: container)
                     return try user.signToken(using: signer, on: container)
                 }
                 .map {

--- a/Sources/Reset/Config/ResetConfig.swift
+++ b/Sources/Reset/Config/ResetConfig.swift
@@ -44,11 +44,11 @@ public extension ResetConfig {
         context: T.Context,
         on req: Request
     ) throws -> Future<Void> {
-        let signer = try object.signer(for: context, on: req)
+        let signer = try T.signer(for: context, on: req)
         return try object.signToken(using: signer, on: req)
             .flatMap(to: Void.self) { token in
                 let url = self.baseURL
-                    .appending("\(self.endpoints.resetPassword ?? "")/\(token)")
+                    .appending("\(self.endpoints.resetPassword ?? "")/\(token)/\(context.description)")
                 return try object.sendPasswordReset(
                     url: url,
                     token: token,

--- a/Sources/Reset/Controllers/ResetController.swift
+++ b/Sources/Reset/Controllers/ResetController.swift
@@ -89,16 +89,12 @@ public extension ResetConfig {
         from req: Request
     ) throws -> U.JWTPayload {
         let token: String = try req.parameters.next()
-        let contextRaw: String = try req.parameters.next()
-        guard let context = U.Context(contextRaw) else { throw Abort(.notFound) }
-        let signer = try U.signer(for: context, on: req)
-
         let payload = try JWT<U.JWTPayload>(
             from: token.convertToData(),
-            verifiedUsing: signer.signer
+            verifiedUsing: signer
         ).payload
 
-        try payload.verify(using: signer.signer)
+        try payload.verify(using: signer)
 
         return payload
     }

--- a/Sources/Reset/Controllers/ResetController.swift
+++ b/Sources/Reset/Controllers/ResetController.swift
@@ -85,9 +85,7 @@ open class ResetController
 }
 
 public extension ResetConfig {
-    public func extractVerifiedPayload(
-        from req: Request
-    ) throws -> U.JWTPayload {
+    public func extractVerifiedPayload(from req: Request) throws -> U.JWTPayload {
         let token: String = try req.parameters.next()
         let payload = try JWT<U.JWTPayload>(
             from: token.convertToData(),

--- a/Sources/Reset/Controllers/ResetController.swift
+++ b/Sources/Reset/Controllers/ResetController.swift
@@ -43,7 +43,7 @@ open class ResetController
 
     open func renderResetPasswordForm(_ req: Request) throws -> Future<Response> {
         let config: ResetConfig<U> = try req.make()
-        let payload = try config.extractVerifiedPayload(from: req)
+        let payload = try config.extractVerifiedPayload(from: req.parameters.next())
 
         return try U
             .authenticate(using: payload, on: req)
@@ -58,7 +58,7 @@ open class ResetController
 
     open func resetPassword(_ req: Request) throws -> Future<Response> {
         let config: ResetConfig<U> = try req.make()
-        let payload = try config.extractVerifiedPayload(from: req)
+        let payload = try config.extractVerifiedPayload(from: req.parameters.next())
 
         return try U
             .authenticate(using: payload, on: req)
@@ -85,8 +85,7 @@ open class ResetController
 }
 
 public extension ResetConfig {
-    public func extractVerifiedPayload(from req: Request) throws -> U.JWTPayload {
-        let token: String = try req.parameters.next()
+    public func extractVerifiedPayload(from token: String) throws -> U.JWTPayload {
         let payload = try JWT<U.JWTPayload>(
             from: token.convertToData(),
             verifiedUsing: signer

--- a/Sources/Reset/PasswordResettable.swift
+++ b/Sources/Reset/PasswordResettable.swift
@@ -77,13 +77,12 @@ where
     /// this value ensures that a password reset token can only be used once.
     var passwordChangeCount: Int { get set }
 
-    static func signer(for context: Context, on container: Container) throws -> ExpireableJWTSigner
+    static func expirationPeriod(for context: Context) -> TimeInterval
 }
 
 public extension PasswordResettable {
-    static func signer(for context: Context, on container: Container) throws -> ExpireableJWTSigner {
-        let defaultSigner: ExpireableJWTSigner = try container.make()
-        return defaultSigner
+    static func expirationPeriod(for context: Context) -> TimeInterval {
+        return 1.hoursInSecs
     }
 }
 

--- a/Sources/Reset/PasswordResettable.swift
+++ b/Sources/Reset/PasswordResettable.swift
@@ -25,27 +25,16 @@ public protocol HasPasswordChangeCount {
     var passwordChangeCount: Int { get }
 }
 
-public protocol HasRequestResetPasswordContext: LosslessStringConvertible {
+public protocol HasRequestResetPasswordContext {
     static func requestResetPassword() -> Self
 }
 
-public extension HasRequestResetPasswordContext where
-    Self: RawRepresentable,
-    Self.RawValue == String
-{
-    public init?(_ description: String) { self.init(rawValue: description) }
-    public var description: String { return self.rawValue }
-}
-
-public enum ResetPasswordContext: String, HasRequestResetPasswordContext {
+public enum ResetPasswordContext: HasRequestResetPasswordContext {
     case userRequestedToResetPassword
 
     public static func requestResetPassword() -> ResetPasswordContext {
         return .userRequestedToResetPassword
     }
-
-    public init?(_ description: String) { self.init(rawValue: description) }
-    public var description: String { return self.rawValue }
 }
 
 public protocol PasswordResettable:

--- a/Sources/Reset/Provider/ResetProvider.swift
+++ b/Sources/Reset/Provider/ResetProvider.swift
@@ -68,13 +68,16 @@ public extension Router {
 
         if let renderResetPasswordPath = endpoints.renderResetPassword {
             get(
-                renderResetPasswordPath, String.parameter,
+                renderResetPasswordPath, String.parameter, String.parameter,
                 use: controller.renderResetPasswordForm
             )
         }
 
         if let resetPasswordPath = endpoints.resetPassword {
-            post(resetPasswordPath, String.parameter, use: controller.resetPassword)
+            post(
+                resetPasswordPath, String.parameter, String.parameter,
+                use: controller.resetPassword
+            )
         }
     }
 }

--- a/Sources/Reset/Provider/ResetProvider.swift
+++ b/Sources/Reset/Provider/ResetProvider.swift
@@ -68,14 +68,14 @@ public extension Router {
 
         if let renderResetPasswordPath = endpoints.renderResetPassword {
             get(
-                renderResetPasswordPath, String.parameter, String.parameter,
+                renderResetPasswordPath, String.parameter,
                 use: controller.renderResetPasswordForm
             )
         }
 
         if let resetPasswordPath = endpoints.resetPassword {
             post(
-                resetPasswordPath, String.parameter, String.parameter,
+                resetPasswordPath, String.parameter,
                 use: controller.resetPassword
             )
         }


### PR DESCRIPTION
Found a bug while preparing an environment. The forms didn't use the correct (context-based) signers when validating. 